### PR TITLE
Os campos relacionados devem ser somente leitura.

### DIFF
--- a/stock_inventory_import/models/stock_inventory.py
+++ b/stock_inventory_import/models/stock_inventory.py
@@ -8,6 +8,13 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 
+class StockInventoryLine(models.Model):
+    _inherit = 'stock.inventory.line'
+
+    product_name = fields.Char(readonly=True)
+    product_code = fields.Char(readonly=True)
+
+
 class StockInventory(models.Model):
     _inherit = "stock.inventory"
 


### PR DESCRIPTION
Evita que o Odoo tente escrever para todos os registros e lance problema
de permissão devido ao multi empresa.