### PR TITLE
Módulo que adiciona os campos iccd, imei e n linha

### DIFF
--- a/product_special_fields/__init__.py
+++ b/product_special_fields/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_special_fields/__manifest__.py
+++ b/product_special_fields/__manifest__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# © 2018 Johny Chen Jy, Trustcode
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{  # pylint: disable=C8101,C8103
+    'name': 'Product Special Fields',
+    'description': "Campos adicionais para controle de stock",
+    'summary': """"Campos adicionais configuráveis no produto, permitindo inserir
+o valor do IMEI, ICCD, No linha""",
+    'version': '11.0.1.0.0',
+    'category': "stock",
+    'author': 'Trustcode',
+    'license': 'AGPL-3',
+    'website': 'http://www.trustcode.com.br',
+    'contributors': [
+        'Johny Chen Jy <johnychenjy@gmail.com>',
+    ],
+    'depends': [
+        'stock',
+        'product',
+    ],
+    'data': [
+        'views/product_template_views.xml',
+        'views/stock_production_lot_views.xml',
+        'views/stock_move_line_views.xml',
+    ],
+}

--- a/product_special_fields/models/__init__.py
+++ b/product_special_fields/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import stock_move_line
+from . import stock_production_lot

--- a/product_special_fields/models/product_template.py
+++ b/product_special_fields/models/product_template.py
@@ -1,0 +1,9 @@
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    imei = fields.Boolean(string=u"IMEI Obrigatório")
+    iccd = fields.Boolean(string=u"ICCD Obrigatório")
+    n_linha = fields.Boolean(string=u"Numero da linha Obrigatório")

--- a/product_special_fields/models/stock_move_line.py
+++ b/product_special_fields/models/stock_move_line.py
@@ -1,0 +1,21 @@
+from odoo import fields, models, _
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    imei = fields.Char(string=_(u"Valor do IMEI"))
+    iccd = fields.Char(string=_(u"Valor do ICCD"))
+    n_linha = fields.Char(string=_(u"Número da Linha"))
+
+    conf_imei = fields.Boolean(related='move_id.product_id.imei')
+    conf_iccd = fields.Boolean(related='move_id.product_id.iccd')
+    conf_n_linha = fields.Boolean(related='move_id.product_id.n_linha')
+
+    def _action_done(self):
+        res = super(StockMoveLine, self)._action_done()
+        for ml in self:
+            if ml.lot_id:
+                ml.lot_id.update(
+                    {'imei': ml.imei, 'iccd': ml.iccd, 'n_linha': ml.n_linha})
+        return res

--- a/product_special_fields/models/stock_production_lot.py
+++ b/product_special_fields/models/stock_production_lot.py
@@ -1,0 +1,9 @@
+from odoo import fields, models, _
+
+
+class ProductionLot(models.Model):
+    _inherit = 'stock.production.lot'
+
+    imei = fields.Char(string=_(u"Valor do IMEI"))
+    iccd = fields.Char(string=_(u"Valor do ICCD"))
+    n_linha = fields.Char(string=_(u"Número da Linha"))

--- a/product_special_fields/views/product_template_views.xml
+++ b/product_special_fields/views/product_template_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_template_property_special_fields_form" model="ir.ui.view">
+        <field name="name">product.template.product.special.fields.tree</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="stock.view_template_property_form"/>
+        <field name="arch" type="xml">
+            <group name="inventory" position="inside">
+                <group string="Campos Especiais" name="special_fields">
+                    <field name="imei"/>
+                    <field name="iccd"/>
+                    <field name="n_linha"/>
+                </group>
+            </group>
+        </field>
+    </record>
+
+</odoo>

--- a/product_special_fields/views/stock_move_line_views.xml
+++ b/product_special_fields/views/stock_move_line_views.xml
@@ -1,0 +1,17 @@
+<odoo>
+        <record id="view_stock_move_line_operation_special_fields_tree" model="ir.ui.view">
+            <field name="name">stock.move.line.operations.special.fields.tree</field>
+            <field name="model">stock.move.line</field>
+            <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree"/>
+            <field name="arch" type="xml">
+                <field name="lot_name" position="after">
+                    <field name="conf_imei" invisible="1"/>
+                    <field name="conf_iccd" invisible="1"/>
+                    <field name="conf_n_linha" invisible="1"/>
+                    <field name="imei" attrs="{'required':[('conf_imei','=',True)],'readonly':[('conf_imei','=',False)]}"/>
+                    <field name="iccd" attrs="{'required':[('conf_iccd','=',True)],'readonly':[('conf_iccd','=',False)]}"/>
+                    <field name="n_linha" attrs="{'required':[('conf_n_linha','=',True)],'readonly':[('conf_n_linha','=',False)]}"/>
+                </field>
+            </field>
+        </record>
+</odoo>

--- a/product_special_fields/views/stock_production_lot_views.xml
+++ b/product_special_fields/views/stock_production_lot_views.xml
@@ -1,0 +1,29 @@
+<odoo>
+    <record id="view_production_special_fields_lot_tree" model="ir.ui.view">
+        <field name="name">stock.production.special.fields.lot.tree</field>
+        <field name="model">stock.production.lot</field>
+        <field name="inherit_id" ref="stock.view_production_lot_tree"/>
+        <field name="arch" type="xml">
+            <field name="ref" position="before">
+                <field name="imei"/>
+                <field name="iccd"/>
+                <field name="n_linha"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="view_production_special_fields_lot_form" model="ir.ui.view">
+        <field name="name">stock.production.special.fields.lot.form</field>
+        <field name="model">stock.production.lot</field>
+        <field name="inherit_id" ref="stock.view_production_lot_form"/>
+        <field name="arch" type="xml">
+            <group name="main_group" position="after">
+                <group>
+                    <field name="imei"/>
+                    <field name="iccd"/>
+                    <field name="n_linha"/>
+                </group>
+            </group>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Mini documentação:
Adicionei 3 campos em 3 views:

View 1: Product.template: lá vão ter 3 checkboxes que determinam quais desses 3 campos serão obrigatórios na entrada de mercadoria.

View 2: stock.production.lot: mesmos campos, porém em colunas 

View 3: stock.move.line: coluna também. Nesse daqui, apenas os campos que foram 'checked' no product.template poderão ser editados. Esses mesmos campos são obrigatórios.

Funcionamento:

PS 1: não esqueça de habilitar o lot/serie nas configurações do inventário e controlar por lote no product.template.

Basicamente, a única coisa que isso tudo faz é preencher uns campos (informados no stock.move.line)
no stock.production.lot

DATS ALL FOLKS.