### PR TITLE
[11.0]commitment and requisition dates

### DIFF
--- a/commitment_requisition_date/__init__.py
+++ b/commitment_requisition_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/commitment_requisition_date/__manifest__.py
+++ b/commitment_requisition_date/__manifest__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# © 2018 Johny Chen Jy <>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{   # pylint: disable=C8101,C8103
+    'name': 'Picking and MRP Commitment and Requisition Dates',
+    'description': "\
+        Commitment and Requisition Dates for stock.picking and mrp.production",
+    'version': '11.0.1.0.0',
+    'category': "Administration",
+    'author': 'Trustcode',
+    'license': 'AGPL-3',
+    'website': 'http://www.trustcode.com.br',
+    'contributors': [
+        'Johny Chen Jy <johnychenjy@gmail.com>',
+    ],
+    'depends': [
+        'mrp',
+        'stock',
+        'sale_order_dates',
+    ],
+    'data': [
+        'views/mrp_production_view.xml',
+        'views/stock_picking_view.xml',
+        'views/sale_order_view.xml',
+    ],
+}

--- a/commitment_requisition_date/models/__init__.py
+++ b/commitment_requisition_date/models/__init__.py
@@ -1,0 +1,5 @@
+from . import mrp_production
+from . import stock_picking
+from . import procurement_rule
+from . import stock_move
+from . import sale_order

--- a/commitment_requisition_date/models/mrp_production.py
+++ b/commitment_requisition_date/models/mrp_production.py
@@ -8,5 +8,7 @@ from odoo import fields, models
 class MrpProduction(models.Model):
     _inherit = "mrp.production"
 
-    commitment_date = fields.Datetime('Data do Compromisso')
-    requisition_date = fields.Datetime('Data do Requisição')
+    commitment_date = fields.Datetime(
+        'Data do Compromisso', track_visibility='onchange')
+    requisition_date = fields.Datetime(
+        'Data do Requisição', track_visibility='onchange')

--- a/commitment_requisition_date/models/mrp_production.py
+++ b/commitment_requisition_date/models/mrp_production.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2018 Johny Chen Jy, Trustcode
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class MrpProduction(models.Model):
+    _inherit = "mrp.production"
+
+    commitment_date = fields.Datetime('Data do Compromisso')
+    requisition_date = fields.Datetime('Data do Requisição')

--- a/commitment_requisition_date/models/procurement_rule.py
+++ b/commitment_requisition_date/models/procurement_rule.py
@@ -1,0 +1,20 @@
+from odoo import models
+
+
+class ProcurementRule(models.Model):
+    _inherit = 'procurement.rule'
+
+    def _prepare_mo_vals(
+            self, product_id, product_qty, product_uom,
+            location_id, name, origin, values, bom):
+
+        res = super(ProcurementRule, self)._prepare_mo_vals(
+            product_id, product_qty, product_uom,
+            location_id, name, origin, values, bom)
+
+        res.update({
+            'commitment_date': values.get('commitment_date') or False,
+            'requisition_date': values.get('requisition_date') or False,
+        })
+
+        return res

--- a/commitment_requisition_date/models/sale_order.py
+++ b/commitment_requisition_date/models/sale_order.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# © 2018 Johny Chen Jy, Trustcode
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    def _sale_order_dates_update(self, vals):
+        if self.procurement_group_id:
+            mrp_production = self.env['mrp.production'].search([
+                ('procurement_group_id', '=', self.procurement_group_id.id)])
+            for production in mrp_production:
+                production.write({
+                    'commitment_date': vals.get('commitment_date'),
+                    'requisition_date': vals.get('requested_date'),
+                    })
+
+        picking_ids = self.picking_ids.filtered(lambda x: x.state != 'cancel')
+
+        for picking in picking_ids:
+            picking.write({
+                'commitment_date': vals.get('commitment_date'),
+                'requisition_date': vals.get('requested_date'),
+            })
+
+    @api.multi
+    def write(self, vals):
+        res = super(SaleOrder, self).write(vals)
+        if any(item in vals for item in ['commitment_date', 'requested_date']):
+            self._sale_order_dates_update({
+                'commitment_date': vals.get('commitment_date'),
+                'requested_date': vals.get('requested_date'),
+            })
+        return res

--- a/commitment_requisition_date/models/sale_order.py
+++ b/commitment_requisition_date/models/sale_order.py
@@ -2,11 +2,14 @@
 # © 2018 Johny Chen Jy, Trustcode
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import api, models, fields
 
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
+
+    commitment_date = fields.Datetime(track_visibility='onchange')
+    requested_date = fields.Datetime(track_visibility='onchange')
 
     def _sale_order_dates_update(self, vals):
         if self.procurement_group_id:

--- a/commitment_requisition_date/models/stock_move.py
+++ b/commitment_requisition_date/models/stock_move.py
@@ -1,0 +1,23 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _prepare_procurement_values(self):
+        res = super(StockMove, self)._prepare_procurement_values()
+
+        res.update({
+            'commitment_date': self.sale_line_id.order_id.commitment_date,
+            'requisition_date': self.sale_line_id.order_id.requested_date,
+        })
+        return res
+
+    def _get_new_picking_values(self):
+        res = super(StockMove, self)._get_new_picking_values()
+
+        res.update({
+            'commitment_date': self.sale_line_id.order_id.commitment_date,
+            'requisition_date': self.sale_line_id.order_id.requested_date,
+        })
+        return res

--- a/commitment_requisition_date/models/stock_picking.py
+++ b/commitment_requisition_date/models/stock_picking.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# © 2018 Johny Chen Jy, Trustcode
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    commitment_date = fields.Datetime('Data do Compromisso')
+    requisition_date = fields.Datetime('Data do Requisição')

--- a/commitment_requisition_date/models/stock_picking.py
+++ b/commitment_requisition_date/models/stock_picking.py
@@ -8,5 +8,7 @@ from odoo import fields, models
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
-    commitment_date = fields.Datetime('Data do Compromisso')
-    requisition_date = fields.Datetime('Data do Requisição')
+    commitment_date = fields.Datetime(
+        'Data do Compromisso', track_visibility='onchange')
+    requisition_date = fields.Datetime(
+        'Data do Requisição', track_visibility='onchange')

--- a/commitment_requisition_date/views/mrp_production_view.xml
+++ b/commitment_requisition_date/views/mrp_production_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="mrp_production_dates_form_view" model="ir.ui.view">
+            <field name="name">mrp.production.dates.form</field>
+            <field name="model">mrp.production</field>
+            <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+            <field name="arch" type="xml">
+                <field name="date_planned_finished" position="after">
+                    <field name="requisition_date" readonly="1"/>
+                    <field name="commitment_date" readonly="1"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/commitment_requisition_date/views/sale_order_view.xml
+++ b/commitment_requisition_date/views/sale_order_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_order_form_inherit_sale_order_dates" model="ir.ui.view">
+        <field name="name">sale.order.date.form.inherit</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale_order_dates.view_order_form_inherit_sale_stock_inherit_sale_order_dates"/>
+        <field name="arch" type="xml">
+            <field name="requested_date" position="attributes">
+                <attribute name="readonly">0</attribute>
+                <attribute name="attrs">{'readonly': False}</attribute>
+            </field>
+            <field name="commitment_date" position="attributes">
+                <attribute name="readonly">0</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/commitment_requisition_date/views/stock_picking_view.xml
+++ b/commitment_requisition_date/views/stock_picking_view.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="stock_picking_dates_form_view" model="ir.ui.view">
+            <field name="name">stock.picking.dates.form</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock.view_picking_form"/>
+            <field name="arch" type="xml">
+                <field name="scheduled_date" position="after">
+                    <field name="requisition_date" readonly="1"/>
+                    <field name="commitment_date" readonly="1"/>
+                </field>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
commitment_date and requirement_date changes:
- fields added to mrp.production adnd stock.pocking with readonly mode
- they are not readonly anymore on sale.order
- when those fields are updated on sale.order, their equivalent fields in mrp.production and stock.picking are updates too (only updated when WRITE method is called)

dats all folks