### PR TITLE
T1419 - Erro de envio de email

### DIFF
--- a/mail_fixes/models/mail_mail.py
+++ b/mail_fixes/models/mail_mail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # © 2017 Danimar Ribeiro, Trustcode
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -14,7 +13,7 @@ class IrMailServer(models.Model):
                    smtp_port=None, smtp_user=None, smtp_password=None,
                    smtp_encryption=None, smtp_debug=False, smtp_session=None):
         from_rfc2822 = extract_rfc2822_addresses(message['From'])[-1]
-        server_id = self.env['ir.mail_server'].search([
+        server_id = self.env['ir.mail_server'].sudo().search([
             ('smtp_user', '=', from_rfc2822)])
         if server_id and server_id[0]:
             if 'Return-Path' in message:
@@ -28,13 +27,13 @@ class MailMail(models.Model):
     _inherit = 'mail.mail'
 
     def send(self, auto_commit=False, raise_exception=False):
-        for email in self.env['mail.mail'].browse(self.ids):
+        for email in self.env['mail.mail'].sudo().browse(self.ids):
             from_rfc2822 = extract_rfc2822_addresses(email.email_from)[-1]
-            server_id = self.env['ir.mail_server'].search([
+            server_id = self.env['ir.mail_server'].sudo().search([
                 ('smtp_user', '=', from_rfc2822)])
             server_id = server_id and server_id[0] or False
             if server_id:
-                self.write(
+                self.sudo().write(
                     {'mail_server_id': server_id[0].id,
                      'reply_to': email.email_from})
         return super(MailMail, self).send(auto_commit=auto_commit,

--- a/mail_fixes/models/mail_mail.py
+++ b/mail_fixes/models/mail_mail.py
@@ -1,3 +1,4 @@
+
 # © 2017 Danimar Ribeiro, Trustcode
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -36,5 +37,21 @@ class MailMail(models.Model):
                 self.sudo().write(
                     {'mail_server_id': server_id[0].id,
                      'reply_to': email.email_from})
+            else:
+                
+                company_mail = self.env.user.company_id.email
+
+                server_id = self.env['ir.mail_server'].sudo().search(
+                            [('smtp_user', '=', company_mail)])
+
+                server_id = server_id and server_id[0] or False
+
+                if company_mail and server_id:
+                    self.sudo().write({
+                        'mail_server_id': server_id[0].id,
+                        'email_from': company_mail,
+                        'reply_to': company_mail,
+                    })
+
         return super(MailMail, self).send(auto_commit=auto_commit,
                                           raise_exception=raise_exception)


### PR DESCRIPTION
# Description

Depois de trocar o servidor SMTP pelo da MultidadosTI, ocorreu o seguinte erro:

> O Envio do e-mail falhou pelo servidor SMTP 'None'.
  SMTPDataError: 550
  5.7.1 Client does not have permissions to send as this sender

Isso ocorre, porque em alguns servidores, o campo `email_from` deve ser o mesmo email do usuário do servidor SMTP cadastrado no Odoo, ou seja, teríamos que ter um servidor cadastrado para cada remetente. Felizmente, isso é corrigido com o modulo `mail_fixes`.
Este modulo procura o servidor de acordo com o email setado no campo `email_from`, caso encontr um servidor cadastrado com o mesmo email, este servidor é utilizado no envio.
Este PR adiciona a seguinte modificação: se não houver nenhum servidor cadastrado com o email do remetente do email, o mesmo utiliza o servidor que possui o usuario igual ao email presente no cadastro da empresa do usuario, trocando, em seguida, o remetente desse email pelo email da empresa.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Realizar o envio de email para a fila de email com um remetente que não possua servidor cadastrado.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
