### PR TITLE
quando concluído uma atividade, a mesma é sempre apagada e vira uma m…

### DIFF
--- a/activity_deadline_notify/models/mail_activity.py
+++ b/activity_deadline_notify/models/mail_activity.py
@@ -90,6 +90,12 @@ class MailActivity(models.Model):
         self.update_notify_time()
         return res
 
+    @api.multi
+    def unlink(self):
+        notify_env = self.env['mail.activity.notify']
+        notify_env.search([('activity_id', 'in', self.ids)]).unlink()
+        return super(MailActivity, self).unlink()
+
 
 class MailActivityNotification(models.Model):
     _name = 'mail.activity.notify'


### PR DESCRIPTION
…ensagem, quando isso ocorria a notificação perdia a referência através do campo activity_id e acusando erro de constraint